### PR TITLE
Concurrency issue when there is no lock

### DIFF
--- a/samples/Samples.Mvc5/Controllers/HomeController.cs
+++ b/samples/Samples.Mvc5/Controllers/HomeController.cs
@@ -143,7 +143,7 @@ namespace Samples.Mvc5.Controllers
                 var tasks = new List<Task>();
                 for (int i = 0; i < 10; i++)
                 {
-                    tasks.Add(service.FooAsync(head));
+                    tasks.Add(service.FooAsync(profiler));
                 }
                 await Task.WhenAll(tasks);
                 return Content("All good");
@@ -152,11 +152,12 @@ namespace Samples.Mvc5.Controllers
 
         class FooService
         {
-            public async Task FooAsync(Timing head)
+            public async Task FooAsync(MiniProfiler profiler)
             {
-                using (new Timing(MiniProfiler.Current, head, "foo async", minSaveMs: 100000))
+                await Task.Delay(10).ConfigureAwait(false);
+                using (profiler.Step("foo async"))
                 {
-                    await Task.Delay(100).ConfigureAwait(false);
+                    await Task.Delay(10).ConfigureAwait(false);
                 }
             }
         }

--- a/samples/Samples.Mvc5/Controllers/HomeController.cs
+++ b/samples/Samples.Mvc5/Controllers/HomeController.cs
@@ -142,7 +142,7 @@ namespace Samples.Mvc5.Controllers
                 var tasks = new List<Task>();
                 for (int i = 0; i < 10; i++)
                 {
-                    tasks.Add(service.FooAsync(profiler));
+                    tasks.Add(service.FooAsync());
                 }
                 await Task.WhenAll(tasks);
                 return Content("All good");
@@ -151,8 +151,9 @@ namespace Samples.Mvc5.Controllers
 
         class FooService
         {
-            public async Task FooAsync(MiniProfiler profiler)
+            public async Task FooAsync()
             {
+                var profiler = MiniProfiler.Current;
                 await Task.Delay(10).ConfigureAwait(false);
                 using (profiler.Step("foo async"))
                 {

--- a/samples/Samples.Mvc5/Controllers/HomeController.cs
+++ b/samples/Samples.Mvc5/Controllers/HomeController.cs
@@ -139,7 +139,6 @@ namespace Samples.Mvc5.Controllers
             var service = new FooService();
             using (profiler.Step("action"))
             {
-                var head = profiler.Head;
                 var tasks = new List<Task>();
                 for (int i = 0; i < 10; i++)
                 {

--- a/samples/Samples.Mvc5/Views/Home/Index.cshtml
+++ b/samples/Samples.Mvc5/Views/Home/Index.cshtml
@@ -65,6 +65,7 @@
                 <li><a href="/Home/MassiveNesting2">Massive Nesting 2</a></li>
                 <li><a href="/Home/ParameterizedSqlWithEnums">Parameterized SQL with Enums</a></li>
                 <li><a href="/Home/MinSaveMs">Test Min Save Ms</a></li>
+                <li><a href="/Home/CallAsync">Async call + Concurrency</a></li>
             </ul>
         </div>
     </div>

--- a/src/MiniProfiler.Shared/Timing.cs
+++ b/src/MiniProfiler.Shared/Timing.cs
@@ -261,6 +261,8 @@ namespace StackExchange.Profiling
             if (Interlocked.Increment(ref _threadsAccessing) > 1)
                 throw new Exception("Concurrent access");
 
+            Task.Delay(10).Wait();
+
             try
             {
                 if (Children == null)
@@ -285,7 +287,6 @@ namespace StackExchange.Profiling
             if (Interlocked.Increment(ref _threadsAccessing) > 1)
                 throw new Exception("Concurrent access");
 
-            Task.Delay(10).Wait();
             try
             {
                 Children?.Remove(timing);

--- a/tests/MiniProfiler.Tests/MiniProfilerTest.cs
+++ b/tests/MiniProfiler.Tests/MiniProfilerTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace StackExchange.Profiling.Tests
@@ -101,36 +99,6 @@ namespace StackExchange.Profiling.Tests
 
                 Assert.True(mp1.Root.Children.Contains(goodTiming));
                 Assert.True(!mp1.Root.Children.Contains(badTiming));
-            }
-        }
-
-        [Fact]
-        public async Task ConcurrencyTest()
-        {
-            MiniProfiler.Settings.ProfilerProvider = new DefaultProfilerProvider();
-
-            MiniProfiler.Settings.ProfilerProvider.Start("test");
-            var profiler = MiniProfiler.Current;
-            var service = new FooService();
-            using (profiler.Step("action"))
-            {
-                var tasks = new List<Task>();
-                for (int i = 0; i < 100; i++)
-                {
-                    tasks.Add(service.FooAsync());
-                }
-                await Task.WhenAll(tasks);
-            }
-        }
-
-        class FooService
-        {
-            public async Task FooAsync()
-            {
-                using (MiniProfiler.Current.Step("foo async"))
-                {
-                    await Task.Delay(10).ConfigureAwait(false);
-                }
             }
         }
 


### PR DESCRIPTION
I think there is an issue in current MiniProfiler V4 when the profiler is used with async code. The issue is caused by lack of thread synchronization when creating instances of Timing. 

This PR demonstrates this issue. It adds a test action that is async. Internally the action makes multiple calls to a service (FooService), the calls are done in parallel and then awaited all together. The invoked service methods (FooAsync) are performing async operations sequentially and measure times for them.

Because the executions of FooAsync are awaited together (using Task.WhenAll) and because FooAsync is using ConfigureAwait(false) internally the continuations in FooAsync will execute in parallel and the Timing.Children list will be accessed from multiple threads concurrently. 

When the concurrency issue reproduces CallAsync should throw an exception which will be reported by the web page as ERROR
